### PR TITLE
Make module configurable, add ability to globally disable image generation

### DIFF
--- a/ImagePlaceholders.module.php
+++ b/ImagePlaceholders.module.php
@@ -8,7 +8,7 @@ use Daun\Placeholders\PlaceholderThumbHash;
 // Register the private namespace used by this module
 wire('classLoader')->addNamespace('Daun', __DIR__ . '/lib');
 
-class ImagePlaceholders extends WireData implements Module
+class ImagePlaceholders extends WireData implements Module, ConfigurableModule
 {
 	protected int $defaultLqipWidth = 20;
 	protected array $generators = [];
@@ -22,14 +22,16 @@ class ImagePlaceholders extends WireData implements Module
 			// PlaceholderDominantColor::class => $this->_('Dominant Color'),
 		];
 
-		// Add settings to image field config screen
-		$this->addHookAfter('FieldtypeImage::getConfigInputfields', $this, 'addImageFieldSettings');
+		if (!$this->placeholder_generation_disabled) {
+			// Add settings to image field config screen
+			$this->addHookAfter('FieldtypeImage::getConfigInputfields', $this, 'addImageFieldSettings');
 
-		// Generate placeholders for existing images on field save
-		$this->addHookAfter('FieldtypeImage::savedField', $this, 'handleImageFieldtypeSave');
+			// Generate placeholders for existing images on field save
+			$this->addHookAfter('FieldtypeImage::savedField', $this, 'handleImageFieldtypeSave');
 
-		// Generate placeholder on image upload
-		$this->addHookAfter('FieldtypeImage::savePageField', $this, 'handleImageUpload');
+			// Generate placeholder on image upload
+			$this->addHookAfter('FieldtypeImage::savePageField', $this, 'handleImageUpload');
+		}
 
 		// Add `$image->lqip` property that returns the placeholder data uri
 		$this->addHookProperty('Pageimage::lqip', function (HookEvent $event) {
@@ -143,6 +145,10 @@ class ImagePlaceholders extends WireData implements Module
 
 		try {
 			return $this->wire()->cache->getFor('image-placeholders', $key, WireCache::expireMonthly, function () use ($type, $placeholder, $width, $height) {
+				if ($this->placeholder_generation_disabled) {
+					return '';
+				}
+
 				$handler = $this->getPlaceholderGenerator($type);
 				return $handler::generateDataURI($placeholder, $width, $height);
 			});

--- a/ImagePlaceholdersConfig.php
+++ b/ImagePlaceholdersConfig.php
@@ -1,0 +1,35 @@
+<?php namespace ProcessWire;
+
+class ImagePlaceholdersConfig extends ModuleConfig
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDefaults(): array
+	{
+		return [
+			'placeholder_generation_disabled' => 0,
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getInputfields(): InputfieldWrapper
+	{
+		$inputfields = parent::getInputfields();
+
+		$inputfields->add([
+		  'type' => 'InputfieldCheckbox',
+		  'name' => 'placeholder_generation_disabled',
+		  'label' => __('Disable Placeholder Generation'),
+		  'columnWidth' => 100,
+		  'defaultValue' => $this->getDefaults()['placeholder_generation_disabled'],
+		  'description' => __('Globally disable placeholder image generation for all fields. Existing placeholder images will not be affected.'),
+		  'checkedValue' => 1,
+		  'uncheckedValue' => 0
+		]);
+
+		return $inputfields;
+	}
+}


### PR DESCRIPTION
Adds a module config setting to globally disable new placeholder image generation. This provides the ability to "pause" new placeholder image generation for all fields that are configured to create LQIP images.

Implementation details:

- Disables all new placeholder image generation from a setting on the module config page
- Calls to the lqip() method and lqip property on Pageimage objects remain available and continue to return existing cached images if they exist
- Hides the "Image Placeholders" settings under the "Details" tab on image field configuration pages

