### PR TITLE
Make getPlaceholderDataUri hookable

### DIFF
--- a/ImagePlaceholders.module.php
+++ b/ImagePlaceholders.module.php
@@ -133,7 +133,7 @@ class ImagePlaceholders extends WireData implements Module, ConfigurableModule
 		return [null, null];
 	}
 
-	protected function getPlaceholderDataUri(Pageimage $image, int $width = 0, int $height = 0): string
+	protected function ___getPlaceholderDataUri(Pageimage $image, int $width = 0, int $height = 0): string
 	{
 		[$type, $placeholder] = $this->getPlaceholder($image, false);
 		if (!$placeholder) return '';


### PR DESCRIPTION
Make `ImagePlaceholders::getPlaceholderDataUri()` hookable to make manipulating output prior to rendering on the page at runtime possible.

```php
<?php

wire()->addHookAfter('ImagePlaceholders::getPlaceholderDataUri', function (HookEvent $e) {
    $image = $e->arguments('image');

    // Add a custom checkbox to an image field for controlling individual image output in
    // fields with multiple images
    if ($image->image_no_lqip) {
        $e->return = '';
    }
  
    // Prevent output for a specific extension
    if ($image->ext === 'png') {
        $e->return = '';
    }
});

```